### PR TITLE
Data-break: isEditable has been renamed to isCalculated

### DIFF
--- a/.cards/local/cardTypes/moduleHome.json
+++ b/.cards/local/cardTypes/moduleHome.json
@@ -5,7 +5,7 @@
         {
             "name": "ismsa/fieldTypes/adoptionStep",
             "displayName": "Target adoption step",
-            "isEditable": true
+            "isCalculated": false
         },
         {
             "name": "base/fieldTypes/owner"

--- a/.cards/local/cardTypes/register.json
+++ b/.cards/local/cardTypes/register.json
@@ -10,7 +10,7 @@
         },
         {
             "name": "ismsa/fieldTypes/adoptionStep",
-            "isEditable": true
+            "isCalculated": false
         },
         {
             "name": "ismsa/fieldTypes/progress"

--- a/.cards/local/cardTypes/riskRegister.json
+++ b/.cards/local/cardTypes/riskRegister.json
@@ -13,7 +13,7 @@
         },
         {
             "name": "ismsa/fieldTypes/adoptionStep",
-            "isEditable": true
+            "isCalculated": false
         }
     ],
     "alwaysVisibleFields": [


### PR DESCRIPTION
In 'cyberismo' tool metadata value `isEditable` has been renamed to `isCalculated` for field types.

The value is flipped; previous "isEditable: false", is now semantically same as "isCalculated: true"; and "isEditable: true", is the same as "isCalculated: false". The default value for a field type is "isCalculated: false".  Card's metadata is not allowed to include a value for calculated field, the values are set by logic programs.