### PR TITLE
Improve the policy checks about  owner and information classification

### DIFF
--- a/.cards/local/calculations/basicPolicyCheck.lp
+++ b/.cards/local/calculations/basicPolicyCheck.lp
@@ -1,8 +1,12 @@
 policyCheckFailure(Card, "ISMS", "Owner is a required field", "Owner has not been defined for this card. Set the owner field.") :-
     card(Card),
-    not field(Card, "cardType", "base/cardTypes/controlledDocument"),
+    field(Card, "cardType", CardType),
+    customField(CardType, "base/fieldTypes/owner"),
+    CardType != "base/cardTypes/controlledDocument",
     not field(Card, "base/fieldTypes/owner", _).
 
 policyCheckFailure(Card, "ISMS", "Classification is a required field", "Classification has not been defined for this card. Set the Classification field.") :-
     card(Card),
+    field(Card, "cardType", CardType),
+    customField(CardType, "base/fieldTypes/informationClassification"),
     not field(Card, "base/fieldTypes/informationClassification", _).


### PR DESCRIPTION
With this change, we will set a policy check failure about a missing owner or information classification only if these fields are included in the card type. This makes it possible to have card types for pages that are not supposed to be editable without owner and information classification.