### PR TITLE
Make the risk levels calculated fields

### DIFF
--- a/.cards/local/calculations/riskLevel.lp
+++ b/.cards/local/calculations/riskLevel.lp
@@ -1,0 +1,37 @@
+% ismsa_riskLevel(Impact, Likelihood, RiskLevel)
+ismsa_riskLevel("veryLow", "veryLow", "veryLow").
+ismsa_riskLevel("veryLow", "low", "veryLow").
+ismsa_riskLevel("veryLow", "moderate", "low").
+ismsa_riskLevel("veryLow", "high", "low").
+ismsa_riskLevel("veryLow", "veryHigh", "moderate").
+ismsa_riskLevel("low", "veryLow", "veryLow").
+ismsa_riskLevel("low", "low", "low").
+ismsa_riskLevel("low", "moderate", "moderate").
+ismsa_riskLevel("low", "high", "moderate").
+ismsa_riskLevel("low", "veryHigh", "moderate").
+ismsa_riskLevel("moderate", "veryLow", "low").
+ismsa_riskLevel("moderate", "low", "moderate").
+ismsa_riskLevel("moderate", "moderate", "moderate").
+ismsa_riskLevel("moderate", "high", "high").
+ismsa_riskLevel("moderate", "veryHigh", "high").
+ismsa_riskLevel("high", "veryLow", "low").
+ismsa_riskLevel("high", "low", "moderate").
+ismsa_riskLevel("high", "moderate", "high").
+ismsa_riskLevel("high", "high", "high").
+ismsa_riskLevel("high", "veryHigh", "veryHigh").
+ismsa_riskLevel("veryHigh", "veryLow", "moderate").
+ismsa_riskLevel("veryHigh", "low", "moderate").
+ismsa_riskLevel("veryHigh", "moderate", "high").
+ismsa_riskLevel("veryHigh", "high", "veryHigh").
+ismsa_riskLevel("veryHigh", "veryHigh", "veryHigh").
+
+field(Risk, "ismsa/fieldTypes/riskInitialRisk", InitialRisk) :-
+    field(Risk, "ismsa/fieldTypes/riskInitialLikelihood", InitialLikelihood),
+    field(Risk, "ismsa/fieldTypes/riskInitialImpact", InitialImpact),
+    ismsa_riskLevel(InitialImpact, InitialLikelihood, InitialRisk).
+
+field(Risk, "ismsa/fieldTypes/riskResidualRisk", ResidualRisk) :-
+    field(Risk, "ismsa/fieldTypes/riskResidualLikelihood", ResidualLikelihood),
+    field(Risk, "ismsa/fieldTypes/riskResidualImpact", ResidualImpact),
+    ismsa_riskLevel(ResidualImpact, ResidualLikelihood, ResidualRisk).
+

--- a/.cards/local/cardTypes/risk.json
+++ b/.cards/local/cardTypes/risk.json
@@ -15,7 +15,8 @@
             "name": "ismsa/fieldTypes/riskInitialImpact"
         },
         {
-            "name": "ismsa/fieldTypes/riskInitialRisk"
+            "name": "ismsa/fieldTypes/riskInitialRisk",
+            "isCalculated": true
         },
         {
             "name": "ismsa/fieldTypes/riskMitigationStrategy"
@@ -27,7 +28,8 @@
             "name": "ismsa/fieldTypes/riskResidualImpact"
         },
         {
-            "name": "ismsa/fieldTypes/riskResidualRisk"
+            "name": "ismsa/fieldTypes/riskResidualRisk",
+            "isCalculated": true
         }
     ],
     "alwaysVisibleFields": [

--- a/.cards/local/templates/moduleHome/c/ismsa_rnt5sg3y/c/ismsa_8m9b33lq/c/ismsa_r0o0vg3d/c/ismsa_cj0tt7ry/c/ismsa_fo9h49wb/c/ismsa_3bsxrmma/index.json
+++ b/.cards/local/templates/moduleHome/c/ismsa_rnt5sg3y/c/ismsa_8m9b33lq/c/ismsa_r0o0vg3d/c/ismsa_cj0tt7ry/c/ismsa_fo9h49wb/c/ismsa_3bsxrmma/index.json
@@ -7,11 +7,9 @@
     "base/fieldTypes/informationClassification": "internal",
     "ismsa/fieldTypes/riskInitialLikelihood": null,
     "ismsa/fieldTypes/riskInitialImpact": null,
-    "ismsa/fieldTypes/riskInitialRisk": null,
     "ismsa/fieldTypes/riskMitigationStrategy": null,
     "ismsa/fieldTypes/riskResidualLikelihood": null,
     "ismsa/fieldTypes/riskResidualImpact": null,
-    "ismsa/fieldTypes/riskResidualRisk": null,
     "links": [],
     "lastUpdated": "2025-01-15T14:42:43.353Z"
 }

--- a/.cards/local/templates/moduleHome/c/ismsa_rnt5sg3y/c/ismsa_8m9b33lq/c/ismsa_r0o0vg3d/c/ismsa_cj0tt7ry/c/ismsa_fo9h49wb/c/ismsa_kc1q46hu/index.json
+++ b/.cards/local/templates/moduleHome/c/ismsa_rnt5sg3y/c/ismsa_8m9b33lq/c/ismsa_r0o0vg3d/c/ismsa_cj0tt7ry/c/ismsa_fo9h49wb/c/ismsa_kc1q46hu/index.json
@@ -7,11 +7,9 @@
     "base/fieldTypes/informationClassification": "internal",
     "ismsa/fieldTypes/riskInitialLikelihood": null,
     "ismsa/fieldTypes/riskInitialImpact": null,
-    "ismsa/fieldTypes/riskInitialRisk": null,
     "ismsa/fieldTypes/riskMitigationStrategy": null,
     "ismsa/fieldTypes/riskResidualLikelihood": null,
     "ismsa/fieldTypes/riskResidualImpact": null,
-    "ismsa/fieldTypes/riskResidualRisk": null,
     "links": [],
     "lastUpdated": "2025-01-15T14:43:13.645Z"
 }

--- a/.cards/local/templates/moduleHome/c/ismsa_rnt5sg3y/c/ismsa_8m9b33lq/c/ismsa_r0o0vg3d/c/ismsa_cj0tt7ry/c/ismsa_fo9h49wb/c/ismsa_sizmh7t2/index.json
+++ b/.cards/local/templates/moduleHome/c/ismsa_rnt5sg3y/c/ismsa_8m9b33lq/c/ismsa_r0o0vg3d/c/ismsa_cj0tt7ry/c/ismsa_fo9h49wb/c/ismsa_sizmh7t2/index.json
@@ -7,11 +7,9 @@
     "base/fieldTypes/informationClassification": "internal",
     "ismsa/fieldTypes/riskInitialLikelihood": null,
     "ismsa/fieldTypes/riskInitialImpact": null,
-    "ismsa/fieldTypes/riskInitialRisk": null,
     "ismsa/fieldTypes/riskMitigationStrategy": null,
     "ismsa/fieldTypes/riskResidualLikelihood": null,
     "ismsa/fieldTypes/riskResidualImpact": null,
-    "ismsa/fieldTypes/riskResidualRisk": null,
     "links": [],
     "lastUpdated": "2025-01-15T14:43:36.328Z"
 }

--- a/.cards/local/templates/risk/c/ismsa_cu9vhbb0/index.json
+++ b/.cards/local/templates/risk/c/ismsa_cu9vhbb0/index.json
@@ -7,9 +7,7 @@
     "base/fieldTypes/informationClassification": null,
     "ismsa/fieldTypes/riskInitialLikelihood": null,
     "ismsa/fieldTypes/riskInitialImpact": null,
-    "ismsa/fieldTypes/riskInitialRisk": null,
     "ismsa/fieldTypes/riskMitigationStrategy": null,
     "ismsa/fieldTypes/riskResidualLikelihood": null,
-    "ismsa/fieldTypes/riskResidualImpact": null,
-    "ismsa/fieldTypes/riskResidualRisk": null
+    "ismsa/fieldTypes/riskResidualImpact": null
 }


### PR DESCRIPTION
This change makes both the initial risk level and the residual risk level calculated fields.

Notice that you need to update Cyberismo in order for this to work, since there was a bug in calculated fields that was just fixed.