### PR TITLE
Add fields to policy check failures

### DIFF
--- a/.cards/local/calculations/assetControl.lp
+++ b/.cards/local/calculations/assetControl.lp
@@ -17,69 +17,69 @@ ismsa_asset(Card, "Supplier") :-
 
 % Criticality and risk evaluation needed are mandatory for all assets
 % Risk evaluation needed can be a calculated field
-policyCheckFailure(Asset, "ISMS", "'Criticality for operations' is a required field", "'Criticality for operations' has not been defined for this asset. Set this field.") :-
+policyCheckFailure(Asset, "ISMS", "'Criticality for operations' is a required field", "'Criticality for operations' has not been defined for this asset. Set this field.", "ismsa/fieldTypes/assetCriticalityForOperations") :-
     ismsa_asset(Asset),
     not field(Asset, "ismsa/fieldTypes/assetCriticalityForOperations", _).
 
-policyCheckFailure(Asset, "ISMS", "'Risk evaluation needed' is a required field", "'Risk evaluation needed' has not been defined for this asset. Set this field.") :-
+policyCheckFailure(Asset, "ISMS", "'Risk evaluation needed' is a required field", "'Risk evaluation needed' has not been defined for this asset. Set this field.", "ismsa/fieldTypes/assetRiskEvaluationNeeded") :-
     ismsa_asset(Asset),
     not field(Asset, "ismsa/fieldTypes/assetRiskEvaluationNeeded", _),
     field(Asset, "cardType", CardType),
     not calculatedField(CardType, "ismsa/fieldTypes/assetRiskEvaluationNeeded").
 
 % Access control, backup(s), security updates and logging & monitoring are mandatory for information systems
-policyCheckFailure(Asset, "ISMS", "'Access control' is a required field", "'Access control' has not been defined for this asset. Set this field.") :-
+policyCheckFailure(Asset, "ISMS", "'Access control' is a required field", "'Access control' has not been defined for this asset. Set this field.", "ismsa/fieldTypes/assetAccessControl") :-
     field(Asset, "cardType", "ismsa/cardTypes/assetInformationSystem"),
     not field(Asset, "ismsa/fieldTypes/assetAccessControl", _).
 
-policyCheckFailure(Asset, "ISMS", "'Security updates' is a required field", "'Security updates' has not been defined for this asset. Set this field.") :-
+policyCheckFailure(Asset, "ISMS", "'Security updates' is a required field", "'Security updates' has not been defined for this asset. Set this field.", "ismsa/fieldTypes/assetUpdates") :-
     field(Asset, "cardType", "ismsa/cardTypes/assetInformationSystem"),
     not field(Asset, "ismsa/fieldTypes/assetUpdates", _).
 
-policyCheckFailure(Asset, "ISMS", "'Backup(s)' is a required field", "'Backup(s)' has not been defined for this asset. Set this field.") :-
+policyCheckFailure(Asset, "ISMS", "'Backup(s)' is a required field", "'Backup(s)' has not been defined for this asset. Set this field.", "ismsa/fieldTypes/assetBackups") :-
     field(Asset, "cardType", "ismsa/cardTypes/assetInformationSystem"),
     not field(Asset, "ismsa/fieldTypes/assetBackups", _).
 
-policyCheckFailure(Asset, "ISMS", "'Logging and monitoring' is a required field", "'Logging and monitoring' has not been defined for this asset. Set this field.") :-
+policyCheckFailure(Asset, "ISMS", "'Logging and monitoring' is a required field", "'Logging and monitoring' has not been defined for this asset. Set this field.", "ismsa/fieldTypes/assetLoggingAndMonitoring") :-
     field(Asset, "cardType", "ismsa/cardTypes/assetInformationSystem"),
     not field(Asset, "ismsa/fieldTypes/assetLoggingAndMonitoring", _).
 
 % Integrity, availability and personal data classification and location are mandatory for data assets
-policyCheckFailure(Asset, "ISMS", "'Integrity' is a required field", "'Integrity' has not been defined for this asset. Set this field.") :-
+policyCheckFailure(Asset, "ISMS", "'Integrity' is a required field", "'Integrity' has not been defined for this asset. Set this field.", "ismsa/fieldTypes/assetIntegrity") :-
     field(Asset, "cardType", "ismsa/cardTypes/assetData"),
     not field(Asset, "ismsa/fieldTypes/assetIntegrity", _).
 
-policyCheckFailure(Asset, "ISMS", "'Availability' is a required field", "'Availability' has not been defined for this asset. Set this field.") :-
+policyCheckFailure(Asset, "ISMS", "'Availability' is a required field", "'Availability' has not been defined for this asset. Set this field.", "ismsa/fieldTypes/assetAvailability") :-
     field(Asset, "cardType", "ismsa/cardTypes/assetData"),
     not field(Asset, "ismsa/fieldTypes/assetAvailability", _).
 
-policyCheckFailure(Asset, "ISMS", "'Contains personal information' is a required field", "'Contains personal information' has not been defined for this asset. Set this field.") :-
+policyCheckFailure(Asset, "ISMS", "'Contains personal information' is a required field", "'Contains personal information' has not been defined for this asset. Set this field.", "ismsa/fieldTypes/assetPersonalInformation") :-
     field(Asset, "cardType", "ismsa/cardTypes/assetData"),
     not field(Asset, "ismsa/fieldTypes/assetPersonalInformation", _).
 
-policyCheckFailure(Asset, "ISMS", "'Location' is a required field", "'Location' has not been defined for this asset. Set this field.") :-
+policyCheckFailure(Asset, "ISMS", "'Location' is a required field", "'Location' has not been defined for this asset. Set this field.", "ismsa/fieldTypes/assetLocation") :-
     field(Asset, "cardType", "ismsa/cardTypes/assetData"),
     not field(Asset, "ismsa/fieldTypes/assetLocation", _).
 
 % Access control, backup(s) and security updates are mandatory for devices
-policyCheckFailure(Asset, "ISMS", "'Access control' is a required field", "'Access control' has not been defined for this asset. Set this field.") :-
+policyCheckFailure(Asset, "ISMS", "'Access control' is a required field", "'Access control' has not been defined for this asset. Set this field.", "ismsa/fieldTypes/assetAccessControl") :-
     field(Asset, "cardType", "ismsa/cardTypes/assetDevice"),
     not field(Asset, "ismsa/fieldTypes/assetAccessControl", _).
 
-policyCheckFailure(Asset, "ISMS", "'Backup(s)' is a required field", "'Backup(s)' has not been defined for this asset. Set this field.") :-
+policyCheckFailure(Asset, "ISMS", "'Backup(s)' is a required field", "'Backup(s)' has not been defined for this asset. Set this field.", "ismsa/fieldTypes/assetBackups") :-
     field(Asset, "cardType", "ismsa/cardTypes/assetDevice"),
     not field(Asset, "ismsa/fieldTypes/assetBackups", _).
 
-policyCheckFailure(Asset, "ISMS", "'Security updates' is a required field", "'Security updates' has not been defined for this asset. Set this field.") :-
+policyCheckFailure(Asset, "ISMS", "'Security updates' is a required field", "'Security updates' has not been defined for this asset. Set this field.", "ismsa/fieldTypes/assetUpdates") :-
     field(Asset, "cardType", "ismsa/cardTypes/assetDevice"),
     not field(Asset, "ismsa/fieldTypes/assetUpdates", _).
 
 % Provided service and contact details are mandatory for suppliers
-policyCheckFailure(Asset, "ISMS", "'Provided services' is a required field", "'Provided services' has not been defined for this asset. Set this field.") :-
+policyCheckFailure(Asset, "ISMS", "'Provided services' is a required field", "'Provided services' has not been defined for this asset. Set this field.", "ismsa/fieldTypes/assetProvidedServices") :-
     field(Asset, "cardType", "ismsa/cardTypes/assetSupplier"),
     not field(Asset, "ismsa/fieldTypes/assetProvidedServices", _).
 
-policyCheckFailure(Asset, "ISMS", "'Contact details' is a required field", "'Contact details' has not been defined for this asset. Set this field.") :-
+policyCheckFailure(Asset, "ISMS", "'Contact details' is a required field", "'Contact details' has not been defined for this asset. Set this field.", "ismsa/fieldTypes/assetContactDetails") :-
     field(Asset, "cardType", "ismsa/cardTypes/assetSupplier"),
     not field(Asset, "ismsa/fieldTypes/assetContactDetails", _).
 

--- a/.cards/local/calculations/basicPolicyCheck.lp
+++ b/.cards/local/calculations/basicPolicyCheck.lp
@@ -1,4 +1,4 @@
-policyCheckFailure(Card, "ISMS", "Owner is a required field", "Owner has not been defined for this card. Set the owner field.") :-
+policyCheckFailure(Card, "ISMS", "Owner is a required field", "Owner has not been defined for this card. Set the owner field.", "base/fieldTypes/owner") :-
     card(Card),
     field(Card, "cardType", CardType),
     customField(CardType, "base/fieldTypes/owner"),
@@ -6,7 +6,7 @@ policyCheckFailure(Card, "ISMS", "Owner is a required field", "Owner has not bee
     not field(Card, "workflowStateCategory", "initial"),
     not field(Card, "base/fieldTypes/owner", _).
 
-policyCheckFailure(Card, "ISMS", "Classification is a required field", "Classification has not been defined for this card. Set the Classification field.") :-
+policyCheckFailure(Card, "ISMS", "Classification is a required field", "Classification has not been defined for this card. Set the Classification field.", "base/fieldTypes/informationClassification") :-
     card(Card),
     field(Card, "cardType", CardType),
     customField(CardType, "base/fieldTypes/informationClassification"),

--- a/.cards/local/calculations/controlControl.lp
+++ b/.cards/local/calculations/controlControl.lp
@@ -8,7 +8,7 @@ transitionDenied(Card, "Not applicable", "Set Status field to N/A" ):-
 
 transitionDenied(Card, "Complete plan", "Fix policy failures before completing plan" ):-
     field(Card, "cardType", "ismsa/cardTypes/control"),
-    policyCheckFailure(Card, _, _, _).
+    base_policyCheckFailure(Card, _, _, _).
 
 editingContentDenied(Card, "You can't edit closed controls" ):-
     field(Card, "cardType", "ismsa/cardTypes/control"),

--- a/.cards/local/calculations/homeControl.lp
+++ b/.cards/local/calculations/homeControl.lp
@@ -1,11 +1,11 @@
 transitionDenied(Card, "Content ready", "Fix policy failures before marking content ready" ):-
     field(Card, "cardType", "ismsa/cardTypes/moduleHome"),
-    policyCheckFailure(Card, _, _, _).
+    base_policyCheckFailure(Card, _, _, _).
 
 transitionDenied(Card, "Content ready", "Fix policy failures in child cards before marking content ready" ):-
     field(Card, "cardType", "ismsa/cardTypes/moduleHome"),
     parent(SubCard,Card),
-    policyCheckFailure(SubCard, _, _, _).
+    base_policyCheckFailure(SubCard, _, _, _).
 
 ismsa_closestHome(Card, Home) :-
     field(Home, "cardType", "ismsa/cardTypes/moduleHome"),

--- a/.cards/local/calculations/incidentControl.lp
+++ b/.cards/local/calculations/incidentControl.lp
@@ -1,14 +1,16 @@
 transitionDenied(Card, "Complete analysis", "Fix policy failures before completing analysis"):-
     field(Card, "cardType", "ismsa/cardTypes/incident"),
-    policyCheckFailure(Card, _, _, _).
+    base_policyCheckFailure(Card, _, _, _).
 
 policyCheckFailure(Card, "ISMS", "Start date and time is a required field",
-    "Start date and time has not been defined for this card. Set the Start date and time field.") :-
+    "Start date and time has not been defined for this card. Set the Start date and time field.",
+    "ismsa/fieldTypes/incidentStartDateTime") :-
     field(Card, "cardType", "ismsa/cardTypes/incident"),
     not field(Card, "ismsa/fieldTypes/incidentStartDateTime", _).
 
 policyCheckFailure(Card, "ISMS", "Incident severity is a required field",
-    "Incident severity has not been defined for this card. Set the Incident severity field.") :-
+    "Incident severity has not been defined for this card. Set the Incident severity field.",
+    "ismsa/fieldTypes/incidentSeverity") :-
     field(Card, "cardType", "ismsa/cardTypes/incident"),
     not field(Card, "ismsa/fieldTypes/incidentSeverity", _).
 

--- a/.cards/local/calculations/registerControl.lp
+++ b/.cards/local/calculations/registerControl.lp
@@ -1,6 +1,6 @@
 transitionDenied(Card, "Content ready", "Fix policy failures for this register before marking content ready" ):-
     field(Card, "cardType", "ismsa/cardTypes/register"),
-    policyCheckFailure(Card, _, _, _).
+    base_policyCheckFailure(Card, _, _, _).
 
 transitionDenied(Card, "Content ready", "Register should contain at least one item before marking content ready" ):-
     field(Card, "cardType", "ismsa/cardTypes/register"),
@@ -14,4 +14,4 @@ transitionDenied(Card, "Content ready", "Register should contain at least one it
 transitionDenied(Card, "Content ready", "Fix policy failures in child cards before marking content ready" ):-
     field(Card, "cardType", "ismsa/cardTypes/register"),
     parent(SubCard,Card),
-    policyCheckFailure(SubCard, _, _, _).
+    base_policyCheckFailure(SubCard, _, _, _).

--- a/.cards/local/calculations/riskControl.lp
+++ b/.cards/local/calculations/riskControl.lp
@@ -17,7 +17,7 @@ transitionDenied(Card, "Complete analysis", "Fill needed metadata fields for thi
     field(Card, "cardType", "ismsa/cardTypes/risk"),
     not field(Card, "base/fieldTypes/informationClassification", _).
 
-policyCheckFailure(Card, "ISMS", "'Initial likelihood' is a required field", "'Initial likelihood' has not been defined for this risk. Set this field.") :-
+policyCheckFailure(Card, "ISMS", "'Initial likelihood' is a required field", "'Initial likelihood' has not been defined for this risk. Set this field.", "ismsa/fieldTypes/riskInitialLikelihood") :-
     field(Card, "cardType", "ismsa/cardTypes/risk"),
     not field(Card, "ismsa/fieldTypes/riskInitialLikelihood", _).
 
@@ -25,7 +25,7 @@ transitionDenied(Card, "Complete analysis", "Fill needed metadata fields for thi
     field(Card, "cardType", "ismsa/cardTypes/risk"),
     not field(Card, "ismsa/fieldTypes/riskInitialLikelihood", _).
 
-policyCheckFailure(Card, "ISMS", "'Initial impact' is a required field", "'Initial impact' has not been defined for this risk. Set this field.") :-
+policyCheckFailure(Card, "ISMS", "'Initial impact' is a required field", "'Initial impact' has not been defined for this risk. Set this field.", "ismsa/fieldTypes/riskInitialImpact") :-
     field(Card, "cardType", "ismsa/cardTypes/risk"),
     not field(Card, "ismsa/fieldTypes/riskInitialImpact", _).
 
@@ -33,15 +33,11 @@ transitionDenied(Card, "Complete analysis", "Fill needed metadata fields for thi
     field(Card, "cardType", "ismsa/cardTypes/risk"),
     not field(Card, "ismsa/fieldTypes/riskInitialImpact", _).
 
-policyCheckFailure(Card, "ISMS", "'Initial risk level' is a required field", "'Initial risk level' has not been defined for this risk. Set this field.") :-
-    field(Card, "cardType", "ismsa/cardTypes/risk"),
-    not field(Card, "ismsa/fieldTypes/riskInitialRisk", _).
-
 transitionDenied(Card, "Complete analysis", "Fill needed metadata fields for this risk before completing analysis" ):-
     field(Card, "cardType", "ismsa/cardTypes/risk"),
     not field(Card, "ismsa/fieldTypes/riskInitialRisk", _).
 
-policyCheckFailure(Card, "ISMS", "Mitigation strategy is a required field", "Mitigation strategy has not been defined for this risk. Set this field.") :-
+policyCheckFailure(Card, "ISMS", "Mitigation strategy is a required field", "Mitigation strategy has not been defined for this risk. Set this field.", "ismsa/fieldTypes/riskMitigationStrategy") :-
     field(Card, "cardType", "ismsa/cardTypes/risk"),
     not field(Card, "ismsa/fieldTypes/riskMitigationStrategy", _).
 

--- a/.cards/local/calculations/taskControl.lp
+++ b/.cards/local/calculations/taskControl.lp
@@ -4,4 +4,4 @@ policyCheckFailure(Card, "ISMS", "Due date is a required field", "Due date has n
 
 transitionDenied(Card, "Approve target", "Fix policy failures before approving target" ):-
     field(Card, "cardType", "ismsa/cardTypes/securityTarget"),
-    policyCheckFailure(Card, _, _, _).
+    base_policyCheckFailure(Card, _, _, _).

--- a/.cards/local/reports/dashboard/query.lp.hbs
+++ b/.cards/local/reports/dashboard/query.lp.hbs
@@ -16,13 +16,13 @@ field(Register, "ismsa/fieldTypes/failureCount", Count + Count2) :-
     field(Register, "cardType", "ismsa/cardTypes/register"),
     Count = #count {
         (Card, Category, Title, Message) :
-        policyCheckFailure(Card, Category, Title, Message),
+        base_policyCheckFailure(Card, Category, Title, Message),
         ancestor(Card, Register),
         not hiddenInTreeView(Card)
     },
     Count2 = #count {
         (Card, Category, Title, Message) :
-        policyCheckFailure(Card, Category, Title, Message),
+        base_policyCheckFailure(Card, Category, Title, Message),
         Card = Register,
         not hiddenInTreeView(Card)
     }.
@@ -31,13 +31,13 @@ field(Register, "ismsa/fieldTypes/failureCount", Count + Count2) :-
     field(Register, "cardType", "ismsa/cardTypes/riskRegister"),
     Count = #count {
         (Card, Category, Title, Message) :
-        policyCheckFailure(Card, Category, Title, Message),
+        base_policyCheckFailure(Card, Category, Title, Message),
         ancestor(Card, Register),
         not hiddenInTreeView(Card)
     },
     Count2 = #count {
         (Card, Category, Title, Message) :
-        policyCheckFailure(Card, Category, Title, Message),
+        base_policyCheckFailure(Card, Category, Title, Message),
         Card = Register,
         not hiddenInTreeView(Card)
     }.

--- a/.cards/local/reports/riskPolicyFailures/query.lp.hbs
+++ b/.cards/local/reports/riskPolicyFailures/query.lp.hbs
@@ -4,14 +4,14 @@ result(Card) :-
    ismsa_closestHome(Card, Home),
    ismsa_closestHome({{cardKey}}, Home),
    field(Card, "cardType", "ismsa/cardTypes/risk"),
-   policyCheckFailure(Card, _, _, _).
+   base_policyCheckFailure(Card, _, _, _).
 
 field(Card, "ismsa/fieldTypes/failureCount", Count) :-
    result(Card),
    Count = #count {
       (Card, Category, Title, Message) :
       result(Card),
-      policyCheckFailure(Card, Category, Title, Message)
+      base_policyCheckFailure(Card, Category, Title, Message)
    }.
 
 orderBy("base/fieldTypes/owner", "ASC").


### PR DESCRIPTION
Use the new feature to add "Go to field" in policy check failures.

Notice that this requires the latest module-base
